### PR TITLE
Fixed broken date selector

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,8 +37,8 @@ var initialize = (function (self) {
 					lon : $(element).attr('data-longitude')
 				},
 				date : $(element)
-					.find('span.date')
-					.text(),
+					.find('span.pl time')
+					.attr('datetime'),
 				hasPic : ($(element)
 					.find('span.l2 span.p')
 					.text()


### PR DESCRIPTION
Craiglist's changed their markup to use the time tag. This is nice because we can now scrape a full datetime. :)