### PR TITLE
Normalize content urls via url-parse library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "babel-polyfill": "^6.13.0",
     "cheerio": "^0.20.0",
     "debug": "^2.2.0",
-    "source-map-support": "^0.4.2"
+    "source-map-support": "^0.4.2",
+    "url-parse" : "^1.1.9"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Update result url normalization path to use url-parse library, rather
than special-casing different url formats. Resolves error in listing
result "url" property due to improper detection of absolute urls in
result page.

Fixes #24.